### PR TITLE
Don't cancel one-shot if other key pressed is a modifier

### DIFF
--- a/src/Kaleidoscope/OneShot.cpp
+++ b/src/Kaleidoscope/OneShot.cpp
@@ -151,7 +151,7 @@ Key OneShot::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_st
 
   // ordinary key here, with some event
 
-  if (keyIsPressed(key_state)) {
+  if (keyIsPressed(key_state) && !isModifier(mapped_key)) {
     if (should_mask_on_interrupt_)
       KeyboardHardware.maskKey(row, col);
     saveAsPrevious(mapped_key);

--- a/src/Kaleidoscope/OneShot.cpp
+++ b/src/Kaleidoscope/OneShot.cpp
@@ -151,11 +151,13 @@ Key OneShot::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_st
 
   // ordinary key here, with some event
 
-  if (keyIsPressed(key_state) && !isModifier(mapped_key)) {
-    if (should_mask_on_interrupt_)
-      KeyboardHardware.maskKey(row, col);
+  if (keyIsPressed(key_state)) {
     saveAsPrevious(mapped_key);
-    should_cancel_ = true;
+    if (!isModifier(mapped_key)) {
+      if (should_mask_on_interrupt_)
+        KeyboardHardware.maskKey(row, col);
+      should_cancel_ = true;
+    }
   }
 
   return mapped_key;


### PR DESCRIPTION
I find myself often wanting to chord a non-oneshot modifier with a one-shot mod (in particular, because I have SpaceCadet on my shift keys). I'm not sure if there's a particular reason why the plugin works differently now, but this seemed like the easiest way to initiate the discussion.