### PR TITLE
GPLv3 (only) & copyright assignment

### DIFF
--- a/examples/OneShot/OneShot.ino
+++ b/examples/OneShot/OneShot.ino
@@ -2,18 +2,17 @@
  * Kaleidoscope-OneShot -- One-shot modifiers and layers
  * Copyright (C) 2016, 2017, 2018  Gergely Nagy
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <Kaleidoscope.h>

--- a/examples/OneShot/OneShot.ino
+++ b/examples/OneShot/OneShot.ino
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-OneShot -- One-shot modifiers and layers
- * Copyright (C) 2016, 2017, 2018  Gergely Nagy
+ * Copyright (C) 2016-2018  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Kaleidoscope-OneShot
 version=0.0.0
 author=Gergely Nagy
-maintainer=Gergely Nagy <kaleidoscope@gergo.csillger.hu>
+maintainer=Gergely Nagy <algernon@keyboard.io>
 sentence=One-shot modifiers and layers for Kaleidoscope.
 paragraph=Provides a way to use one-shot modifiers and layers.
 category=Communication

--- a/src/Kaleidoscope-OneShot.h
+++ b/src/Kaleidoscope-OneShot.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-OneShot -- One-shot modifiers and layers
- * Copyright (C) 2016, 2017  Gergely Nagy
+ * Copyright (C) 2016-2018  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/Kaleidoscope-OneShot.h
+++ b/src/Kaleidoscope-OneShot.h
@@ -2,18 +2,17 @@
  * Kaleidoscope-OneShot -- One-shot modifiers and layers
  * Copyright (C) 2016, 2017  Gergely Nagy
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/Kaleidoscope/OneShot.cpp
+++ b/src/Kaleidoscope/OneShot.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-OneShot -- One-shot modifiers and layers
- * Copyright (C) 2016, 2017, 2018  Gergely Nagy
+ * Copyright (C) 2016-2018  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/Kaleidoscope/OneShot.cpp
+++ b/src/Kaleidoscope/OneShot.cpp
@@ -2,18 +2,17 @@
  * Kaleidoscope-OneShot -- One-shot modifiers and layers
  * Copyright (C) 2016, 2017, 2018  Gergely Nagy
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <Kaleidoscope-OneShot.h>

--- a/src/Kaleidoscope/OneShot.h
+++ b/src/Kaleidoscope/OneShot.h
@@ -2,18 +2,17 @@
  * Kaleidoscope-OneShot -- One-shot modifiers and layers
  * Copyright (C) 2016, 2017, 2018  Gergely Nagy
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/Kaleidoscope/OneShot.h
+++ b/src/Kaleidoscope/OneShot.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-OneShot -- One-shot modifiers and layers
- * Copyright (C) 2016, 2017, 2018  Gergely Nagy
+ * Copyright (C) 2016-2018  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
The first commit changes the license to GPLv3 (only), to match that of Kaleidoscope (as of keyboardio/Kaleidoscope#355). In the second, I assign my copyright to Keyboard.io, Inc.